### PR TITLE
Opțiune run_sanitizers in CompilerFlags.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,8 @@ add_executable(${MAIN_EXECUTABLE_NAME}
 )
 
 # NOTE: Add all defined targets (e.g. executables, libraries, etc. )
-set_compiler_flags(TARGET_NAMES ${MAIN_EXECUTABLE_NAME})
+# NOTE: RUN_SANITIZERS is optional, if it's not present it will default to true
+set_compiler_flags(RUN_SANITIZERS TRUE TARGET_NAMES ${MAIN_EXECUTABLE_NAME})
 # set_compiler_flags(TARGET_NAMES ${MAIN_EXECUTABLE_NAME} ${FOO} ${BAR})
 # where ${FOO} and ${BAR} represent additional executables or libraries
 # you want to compile with the set compiler flags

--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -38,6 +38,5 @@ function(set_compiler_flags)
         if("${ARG_RUN_SANITIZERS}" STREQUAL "TRUE")
             set_custom_stdlib_and_sanitizers(${TARGET_NAME} true)
         endif ()
-
     endforeach ()
 endfunction()

--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -4,7 +4,12 @@ include(cmake/CustomStdlibAndSanitizers.cmake)
 
 function(set_compiler_flags)
     set(multiValueArgs TARGET_NAMES)
-    cmake_parse_arguments(PARSE_ARGV 0 ARG "" "" "${multiValueArgs}")
+    set(oneValueArgs RUN_SANITIZERS)
+    cmake_parse_arguments(PARSE_ARGV 0 ARG "" "${oneValueArgs}" "${multiValueArgs}")
+
+    if(NOT DEFINED ARG_RUN_SANITIZERS)
+        set(ARG_RUN_SANITIZERS TRUE)
+    endif()
 
     # iterate over all specified targets
     foreach (TARGET_NAME IN LISTS ARG_TARGET_NAMES)
@@ -30,6 +35,9 @@ function(set_compiler_flags)
         ###############################################################################
 
         # sanitizers
-        set_custom_stdlib_and_sanitizers(${TARGET_NAME} true)
+        if("${ARG_RUN_SANITIZERS}" STREQUAL "TRUE")
+            set_custom_stdlib_and_sanitizers(${TARGET_NAME} true)
+        endif ()
+
     endforeach ()
 endfunction()


### PR DESCRIPTION
Adăugat opțiune de run_sanitizers in CompilerFlags.cmake în cazul în care, pe un build care folosește sanitizers, nu vrem să fie rulate aceastea pe o parte din build.