### PR TITLE
Update gh-release version to avoid releases getting stuck in retry loop

### DIFF
--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -35,7 +35,7 @@ runs:
 
     - name: Release
       # renovate: datasource=github-tags depName=softprops/action-gh-release versioning=loose
-      uses: softprops/action-gh-release@v2.5.0
+      uses: softprops/action-gh-release@v2.5.1
       if: startsWith(github.ref, 'refs/tags/')
       with:
         files: |


### PR DESCRIPTION
See https://github.com/softprops/action-gh-release/releases/tag/v2.5.1